### PR TITLE
Return ZK eventChannel part of the ZK store

### DIFF
--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
-	zk "github.com/samuel/go-zookeeper/zk"
+
+	"github.com/samuel/go-zookeeper/zk"
 )
 
 const (
@@ -21,6 +22,8 @@ const (
 type Zookeeper struct {
 	timeout time.Duration
 	client  *zk.Conn
+	// EventChan is a channel forwarding ZK connection events
+	EventChan <-chan zk.Event
 }
 
 type zookeeperLock struct {
@@ -49,11 +52,12 @@ func New(endpoints []string, options *store.Config) (store.Store, error) {
 	}
 
 	// Connect to Zookeeper
-	conn, _, err := zk.Connect(endpoints, s.timeout)
+	conn, evChan, err := zk.Connect(endpoints, s.timeout)
 	if err != nil {
 		return nil, err
 	}
 	s.client = conn
+	s.EventChan = evChan
 
 	return s, nil
 }

--- a/store/zookeeper/zookeeper_test.go
+++ b/store/zookeeper/zookeeper_test.go
@@ -26,6 +26,8 @@ func makeZkClient(t *testing.T) store.Store {
 		t.Fatalf("cannot create store: %v", err)
 	}
 
+	assert.NotNil(t, kv.(*Zookeeper).EventChan)
+
 	return kv
 }
 


### PR DESCRIPTION
In the open source library `github.com/docker/libkv`, the current implementation of the ZooKeeper store does not handle the connection to ZooKeeper dropping.

Returning a channel steaming ZooKeeper events as part of the ZK store can help to detect when such a disconnection happens, so a reconnection attempt can be performed.