### PR TITLE
Declare lost lock when ZooKeeper Session Expired 

### DIFF
--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
-	zk "github.com/samuel/go-zookeeper/zk"
+
+	"github.com/samuel/go-zookeeper/zk"
 )
 
 const (
@@ -21,6 +22,8 @@ const (
 type Zookeeper struct {
 	timeout time.Duration
 	client  *zk.Conn
+	// EventChan is a channel forwarding ZK connection events
+	EventChan <-chan zk.Event
 }
 
 type zookeeperLock struct {
@@ -49,11 +52,12 @@ func New(endpoints []string, options *store.Config) (store.Store, error) {
 	}
 
 	// Connect to Zookeeper
-	conn, _, err := zk.Connect(endpoints, s.timeout)
+	conn, evChan, err := zk.Connect(endpoints, s.timeout)
 	if err != nil {
 		return nil, err
 	}
 	s.client = conn
+	s.EventChan = evChan
 
 	return s, nil
 }

--- a/store/zookeeper/zookeeper_test.go
+++ b/store/zookeeper/zookeeper_test.go
@@ -26,7 +26,7 @@ func makeZkClient(t *testing.T) store.Store {
 		t.Fatalf("cannot create store: %v", err)
 	}
 
-	assert.NotNil(t, kv.(*Zookeeper).EventChan)
+	assert.NotNil(t, kv.(*Zookeeper).zkEventChan)
 
 	return kv
 }

--- a/store/zookeeper/zookeeper_test.go
+++ b/store/zookeeper/zookeeper_test.go
@@ -26,6 +26,8 @@ func makeZkClient(t *testing.T) store.Store {
 		t.Fatalf("cannot create store: %v", err)
 	}
 
+	assert.NotNil(t, kv.(*Zookeeper).EventChan)
+
 	return kv
 }
 


### PR DESCRIPTION
The library `docker/leadership` is using `docker/libkv` as a ZooKeeper store interface in order to perform ZK based leader election. The `docker/leadership` lib can perform re-election if need be, however there is currently no support for the following scenario:
```
An ephemeral znode can disappear after a network connection loss to ZK longer than the znode timeout. After reconnection, the session will be expired, the lock needs to be considered lost.
```

This behavior should be handled by a `lock lost channel` getting closed on the ZK store side, this channel closing triggering another loop of leader election campaigning, see https://github.com/docker/leadership/blob/master/candidate.go#L146

Listening on ZK events for a session being expired would enable to declare a lock lost.

The ZK based leader election can now support both:
- network connection loss to ZK for duration < ephemeral znode timeout:
ephemeral znode does NOT disappear, session does not expire, no leader reelection
- network connection loss to ZK for duration > ephemeral znode timeout:
ephemeral znode does disappear (triggering leader reelection), session expires, once network connection to ZK alive again: new session created, new ephemeral znode created, being by default a follower.
